### PR TITLE
Only add specific assets (app.css/.js) plus .DS_Store to gitignore

### DIFF
--- a/src/stubs/gitignore-stub
+++ b/src/stubs/gitignore-stub
@@ -2,8 +2,8 @@
 /public/hot
 /public/storage
 /public/build
-/public/css
-/public/js
+/public/css/app.css
+/public/js/app.js
 /public/mix-manifest.json
 /storage/*.key
 /vendor
@@ -14,3 +14,4 @@ Homestead.yaml
 npm-debug.log
 yarn-error.log
 .env
+.DS_Store


### PR DESCRIPTION
It could be handy to add some static assets or other vendor files in `/public/css` and `/public/js`. Sure the ideal way shouldn't be that path, but in some cases there are valid reasons.

Excluding the whole path wouldn't make that possible, so I replaced them with the `app.css` and `app.js` files according to the mix config.

Additionally I've added `.DS_Store`. Clearing the git cache and readding everything (e.g. a gitignore update), would add these files if they aren't ignored in the global config. Personally, I always forget that, so sometimes I end up with them in my repository. Since they don't harm in any gitignore, they're also added in this PR.