### PR TITLE
Laravel mix cache-busting/version in production

### DIFF
--- a/src/stubs/webpack.mix.js
+++ b/src/stubs/webpack.mix.js
@@ -13,4 +13,8 @@ mix.js('resources/assets/js/app.js', 'public/js')
       }),
     ]
   })
-  .purgeCss()
+
+if (mix.inProduction()) {
+    mix.purgeCss()
+      .version()
+}

--- a/src/stubs/webpack.mix.js
+++ b/src/stubs/webpack.mix.js
@@ -13,8 +13,8 @@ mix.js('resources/assets/js/app.js', 'public/js')
       }),
     ]
   })
+  .purgeCss()
 
 if (mix.inProduction()) {
-    mix.purgeCss()
-      .version()
+    mix.version()
 }


### PR DESCRIPTION
To speed up compiling while developing, `.purgeCss()` only runs in production. Plus I added `.version()`.